### PR TITLE
Feature: getservers running port

### DIFF
--- a/include/Polymorph/Network/tcp/Server.hpp
+++ b/include/Polymorph/Network/tcp/Server.hpp
@@ -54,6 +54,12 @@ namespace polymorph::network::tcp
         public:
             void start();
 
+            /**
+             * @brief get the port used by the server
+             * @return The port number
+             */
+            std::uint16_t getRunningPort() const;
+
             template<typename T>
             void sendTo(OpId opId, T &data, SessionId sessionId, std::function<void(const PacketHeader &, const T &)> callback = nullptr)
             {

--- a/include/Polymorph/Network/udp/Server.hpp
+++ b/include/Polymorph/Network/udp/Server.hpp
@@ -60,6 +60,12 @@ namespace polymorph::network::udp
         /////////////////////////////// METHODS /////////////////////////////////
         public:
         /**
+         * @brief get the port used by the server
+         * @return The port number
+         */
+        std::uint16_t getRunningPort() const;
+
+        /**
          * @brief Method called when an ack packet is received, it confirm the reception and discard the auto re-send feature for the packet
          * @param from The recipient of the initial packet
          * @param acknowledgedId The acknowledged packet id

--- a/src/src/tcp/Server.cpp
+++ b/src/src/tcp/Server.cpp
@@ -38,3 +38,8 @@ polymorph::network::tcp::Server::~Server()
     if (!_context.stopped())
         _context.stop();
 }
+
+std::uint16_t polymorph::network::tcp::Server::getRunningPort() const
+{
+    return _acceptor.local_endpoint().port();
+}

--- a/src/src/udp/Server.cpp
+++ b/src/src/udp/Server.cpp
@@ -122,3 +122,8 @@ void polymorph::network::udp::Server::_handleSessionTransfer(const asio::ip::udp
 
     sendTo<SessionTransferResponseDto>(SessionTransferResponseDto::opId, response, packet.header.sId);
 }
+
+std::uint16_t polymorph::network::udp::Server::getRunningPort() const
+{
+    return _socket.local_endpoint().port();
+}


### PR DESCRIPTION
# Description

Added methods on UDP and TCP servers to get the port they are using to listen connections

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the needed labels
- [ ] I have linked this PR to an issue
- [ ] I have linked this PR to a milestone
- [ ] I have linked this PR to a project
- [x] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [x] I have updated the README and other relevant documents (guides...)
- [x] I have added sufficient documentation both in code, as well as in the READMEs